### PR TITLE
Keep fields populated on a failed registration

### DIFF
--- a/src/main/java/app/models/AuthenticatedUserValidator.java
+++ b/src/main/java/app/models/AuthenticatedUserValidator.java
@@ -58,8 +58,12 @@ public class AuthenticatedUserValidator implements Validator{
             errors.rejectValue("number", "Invalid.userForm.professorNumber");
         }
 
-        if(!(type.equals("Student") || type.equals("Professor") || !type.equals("Coordinator"))) {
-            errors.rejectValue("number", "Invalid.userForm.type");
+        if(type.equals("Coordinator") && !(professorRepository.findByProfNumber(number) instanceof ProjectCoordinator)) {
+            errors.rejectValue("number", "Invalid.userForm.professorNumber.coordinator");
+        }
+
+        if(!(type.equals("Student") || type.equals("Professor") || type.equals("Coordinator"))) {
+            errors.rejectValue("type", "Invalid.userForm.type");
         }
     }
 }

--- a/src/main/resources/templates/registration.html
+++ b/src/main/resources/templates/registration.html
@@ -11,26 +11,26 @@
         <form method="POST" class="form-signin" th:object="${userForm}">
             <h2 class="form-signin-heading">Create your account</h2>
             <div th:class="'form-group '+${#fields.hasErrors('username') ? 'has-error' : ''}">
-                <input type="text" class="form-control" name="username" placeholder="Username" autofocus="true"></input>
+                <input type="text" class="form-control" name="username" placeholder="Username" autofocus="true" th:value="${userForm.username}"></input>
                 <span th:each="e : ${#fields.errors('username')}" th:text="${e}+' '"></span>
             </div>
             <div th:class="'form-group '+${#fields.hasErrors('password') ? 'has-error' : ''}">
-                <input type="password" class="form-control" name="password" placeholder="Password"></input>
+                <input type="password" class="form-control" name="password" placeholder="Password" th:value="${userForm.password}"></input>
                 <span th:each="e : ${#fields.errors('password')}" th:text="${e}+' '"></span>
             </div>
             <div th:class="'form-group '+${#fields.hasErrors('passwordConfirm') ? 'has-error' : ''}">
-                <input type="password" class="form-control" name="passwordConfirm" placeholder="Confirm your password"></input>
+                <input type="password" class="form-control" name="passwordConfirm" placeholder="Confirm your password" th:value="${userForm.passwordConfirm}"></input>
                 <span th:each="e : ${#fields.errors('passwordConfirm')}" th:text="${e}+' '"></span>
             </div>
             <div th:class="'form-group '+${#fields.hasErrors('number') ? 'has-error' : ''}">
-                <input type="text" class="form-control" name="number" placeholder="Number"></input>
+                <input type="text" class="form-control" name="number" placeholder="Number" th:value="${userForm.number}"></input>
                 <span th:each="e : ${#fields.errors('number')}" th:text="${e}+' '"></span>
             </div>
             <div class="form-group">
                 <select class="form-control" name="type">
-                    <option value="Student">Student</option>
-                    <option value="Professor">Professor</option>
-                    <option value="Coordinator">Project Coordinator</option>
+                    <option value="Student" th:selected="${userForm.type == 'Student'}">Student</option>
+                    <option value="Professor" th:selected="${userForm.type == 'Professor'}">Professor</option>
+                    <option value="Coordinator" th:selected="${userForm.type == 'Coordinator'}">Project Coordinator</option>
                 </select>
             </div>
             <button class="btn btn-lg btn-primary btn-block" type="submit">Submit</button>

--- a/src/main/resources/validation.properties
+++ b/src/main/resources/validation.properties
@@ -4,4 +4,8 @@ Duplicate.userForm.username=The username is already in use.
 Size.userForm.password=Please use at least 8 characters.
 Diff.userForm.passwordConfirm=The password confirmation doesn't match.
 Invalid.userForm.studentNumber=No student record with that number.
-Invalid.userForm.professorNumber=No professor record with that number
+Invalid.userForm.professorNumber=No professor record with that number.
+Invalid.userForm.professorNumber.coordinator=That professor is not a coordinator.
+Invalid.userForm.type=Type is invalid.
+
+Duplicate.professorForm.profNumber=A professor with that number already exists.


### PR DESCRIPTION
On a failed registration, fields were being reset to empty before. This PR will have the values remain on page reload.

One other thing. It fixes the validation check for the Coordinator type. (there was an extra `!` in there for some reason)